### PR TITLE
Add a script to deploy to the gh-pages branch, including the CNAME file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ GitHub Actions are not enabled in the Janelia Fly EM repo, and the necessary sec
 To manually deploy the website to GitHub pages, run:
 
 ```bash
-uv run mkdocs gh-deploy --force
+./deploy-gh-pages.sh
 ```

--- a/deploy-gh-pages.sh
+++ b/deploy-gh-pages.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+uv run mkdocs gh-deploy --force
+
+# We need to add this file to enable male-cns.janelia.org host the github.io site.
+echo "male-cns.janelia.org" > CNAME
+git add CNAME
+git commit -m 'add CNAME'
+git push origin gh-pages


### PR DESCRIPTION
This is necessary to preserve the custom domain setting in this repo.  Otherwise that setting is erased upon force-push to the `gh-pages` branch.