### PR TITLE
Fix clio link on the front page 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ icon: material/home
 
     [:octicons-arrow-right-24: NeuPrint](https://neuprint.janelia.org/?dataset=male-cns%3Av0.9&qt=findneurons)
 
-    [:octicons-arrow-right-24: Clio](https://clio.janelia.org/ws/annotate?dataset=male-cns:v0.9&tab=bodies)
+    [:octicons-arrow-right-24: Clio](https://clio.janelia.org/ws/annotate?dataset=male-cns:v0.9-v0.9&tab=bodies)
 
 -   :material-gender-male-female:{ .lg .middle } __Compare__
 


### PR DESCRIPTION
...so it links directly to the male-cns:v0.9 body annotations tab

(I already pushed the fix directly to the `gh-pages` branch.  This PR is just so we don't forget it in future deployments.